### PR TITLE
Include jasmine tests in Rspec runs; prep for CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,5 +25,5 @@ end
 group :development, :test do
   gem 'rspec-rails'
   gem 'factory_girl_rails'
-  gem 'jasmine'
+  gem 'jasmine-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,12 +76,12 @@ GEM
       tilt
     hike (1.2.3)
     i18n (0.7.0)
-    jasmine (2.1.0)
-      jasmine-core (~> 2.1.0)
-      phantomjs
-      rack (>= 1.2.1)
-      rake
     jasmine-core (2.1.3)
+    jasmine-rails (0.10.6)
+      jasmine-core (>= 1.3, < 3.0)
+      phantomjs
+      railties (>= 3.1.0)
+      sprockets-rails
     jquery-rails (4.0.3)
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
@@ -186,7 +186,7 @@ DEPENDENCIES
   bootstrap-sass
   factory_girl_rails
   haml
-  jasmine
+  jasmine-rails
   jquery-rails
   mysql2
   rails (>= 4.1)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,5 @@
 Rails.application.configure do
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # The test environment is used exclusively to run your application's
@@ -33,6 +34,9 @@ Rails.application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
+
+  # For CI deployment
+  config.secret_key_base = ENV["SECRET_KEY_BASE"]
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount JasmineRails::Engine => "/specs" if defined?(JasmineRails)
+
   root 'revenue_sources#index'
 
   resources :revenue_sources, only: [:index, :new, :create, :update]

--- a/spec/javascripts/fixtures/jasmine_spec.rb
+++ b/spec/javascripts/fixtures/jasmine_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'rake'
+
+RSpec.describe 'Jasmine suite', :js do
+  before :all do
+    Ramp::Application.load_tasks
+  end
+
+  it 'test' do
+    puts "\nRunning Jasmine..."
+    expect { Rake::Task['spec:javascript'].invoke }.not_to raise_exception
+  end
+end

--- a/spec/javascripts/react/revenue_sources_spec.js
+++ b/spec/javascripts/react/revenue_sources_spec.js
@@ -1,0 +1,5 @@
+describe('RevenueSourcesSection', function() {
+  it('passes on true', function() {
+    expect(true).toBe(true)
+  });
+});

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -51,7 +51,7 @@ helpers:
 #   - **/*[sS]pec.js
 #
 spec_files:
-  - '**/*[sS]pec.js'
+  - '**/*[sS]pec.{js}'
 
 # src_dir
 #
@@ -121,4 +121,3 @@ boot_files:
 #
 # rack_options:
 #   server: 'thin'
-


### PR DESCRIPTION
_CLI_:
- `rspec spec` includes all Jasmine tests as part of all specs (`rspec` runs normally otherwise)
- `RAILS_ENV=test bundle exec rake spec:javascript` will run just Jasmine specs

_Browser_:
- http://127.0.0.1:3000/specs will run Jasmine tests

_Other_:
- Semaphore CI now prepped 
- `CodeClimate` analysis now prepped

